### PR TITLE
Extract text plugin to fix missing style at first load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# build folder
+dist

--- a/app/index.html
+++ b/app/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>REA</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel='stylesheet' type='text/css' href='main.css'>
   </head>
   <body>
       <div id='container'>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4212,6 +4212,11 @@
         }
       }
     },
+    "webpack-sources": {
+      "version": "0.1.2",
+      "from": "webpack-sources@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.2.tgz"
+    },
     "websocket-driver": {
       "version": "0.6.5",
       "from": "websocket-driver@>=0.5.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "coveralls": "^2.11.9",
     "css-loader": "^0.23.1",
     "enzyme": "^2.3.0",
+    "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
     "istanbul": "^1.0.0-alpha",
     "jsdom": "^9.2.1",

--- a/server.js
+++ b/server.js
@@ -64,6 +64,7 @@ function renderFullPage(html, initialState) {
     <meta charset="utf-8">
     <title>REA</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel='stylesheet' type='text/css' href='main.css'>
   </head>
   <body>
       <div id='container'>${html}</div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 var webpack = require('webpack');
 var path = require('path');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 var query = {
   presets: ['es2015', 'react', 'stage-1']
@@ -33,7 +34,13 @@ module.exports = {
         test: /\.html$/,
         loader: "file?name=[name].[ext]",
       },
-      { test: /\.css$/, loader: "style-loader!css-loader"},
+      {
+        test: /\.css$/,
+        loader: ExtractTextPlugin.extract(
+          "style-loader",
+          "css-loader"
+        )
+      },
       { test: /\.png$/, loader: "url-loader?limit=100000"},
       { test: /\.(ttf|otf|eot|svg|woff(2)?)$/, loader: "url-loader?limit=100000"},
       { test: /\.(jpg|gif)$/, loader: "file-loader" }
@@ -41,7 +48,8 @@ module.exports = {
   },
 
   plugins: [
-    new webpack.HotModuleReplacementPlugin()
+    new webpack.HotModuleReplacementPlugin(),
+    new ExtractTextPlugin("main.css")
   ]
 
 }


### PR DESCRIPTION
Solved #4
## Problem:
- Since we use webpack `css-loader` and `style-loader` in order to `import/require` css files in javascript component code. What it does is under the hood, it concats all the required css files then **inject** those css styles in the **head** of the page **after** js bundle is executed. That's why we missed the css style at first load.
## Solution:
- To get rid of this problem, we can use [text-extract-plugin](https://github.com/webpack/extract-text-webpack-plugin) of webpack, what it does is our styles are no longer inlined into the javascript, but separate in a css bundle file.
### Note:
- We need to manually link css file (`main.css` for example) in the `head` of the page.
- Webpack text extract plugin can be used on top of **css-load** and **style-loader**
